### PR TITLE
use root dir instead of dir for root related configuration

### DIFF
--- a/addressbook-fullstack-javalin/build.gradle.kts
+++ b/addressbook-fullstack-javalin/build.gradle.kts
@@ -136,10 +136,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -148,7 +148,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -165,7 +165,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/addressbook-fullstack-jooby/build.gradle.kts
+++ b/addressbook-fullstack-jooby/build.gradle.kts
@@ -139,10 +139,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -157,7 +157,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -174,7 +174,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/addressbook-fullstack-ktor/build.gradle.kts
+++ b/addressbook-fullstack-ktor/build.gradle.kts
@@ -136,10 +136,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -148,7 +148,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -165,7 +165,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/addressbook-fullstack-micronaut/build.gradle.kts
+++ b/addressbook-fullstack-micronaut/build.gradle.kts
@@ -173,10 +173,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -185,7 +185,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -215,7 +215,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/addressbook-fullstack-spring-boot/build.gradle.kts
+++ b/addressbook-fullstack-spring-boot/build.gradle.kts
@@ -141,10 +141,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -153,7 +153,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -170,7 +170,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/addressbook-fullstack-vertx/build.gradle.kts
+++ b/addressbook-fullstack-vertx/build.gradle.kts
@@ -140,10 +140,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -157,7 +157,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -175,7 +175,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/addressbook-tabulator/build.gradle.kts
+++ b/addressbook-tabulator/build.gradle.kts
@@ -69,10 +69,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -81,7 +81,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -98,7 +98,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/addressbook/build.gradle.kts
+++ b/addressbook/build.gradle.kts
@@ -68,10 +68,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -80,7 +80,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -97,7 +97,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -69,10 +69,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -81,7 +81,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -98,7 +98,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/encoder-fullstack-ktor/build.gradle.kts
+++ b/encoder-fullstack-ktor/build.gradle.kts
@@ -126,10 +126,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -138,7 +138,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -155,7 +155,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/helloworld/build.gradle.kts
+++ b/helloworld/build.gradle.kts
@@ -66,10 +66,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -78,7 +78,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -95,7 +95,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/numbers-fullstack-javalin/build.gradle.kts
+++ b/numbers-fullstack-javalin/build.gradle.kts
@@ -116,10 +116,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -128,7 +128,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -145,7 +145,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/numbers-fullstack-jooby/build.gradle.kts
+++ b/numbers-fullstack-jooby/build.gradle.kts
@@ -120,10 +120,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -138,7 +138,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -155,7 +155,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/numbers-fullstack-ktor/build.gradle.kts
+++ b/numbers-fullstack-ktor/build.gradle.kts
@@ -124,10 +124,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -136,7 +136,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -153,7 +153,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/numbers-fullstack-spring-boot/build.gradle.kts
+++ b/numbers-fullstack-spring-boot/build.gradle.kts
@@ -126,10 +126,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -138,7 +138,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -155,7 +155,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/onsenui-kitchensink/build.gradle.kts
+++ b/onsenui-kitchensink/build.gradle.kts
@@ -68,10 +68,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -80,7 +80,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -97,7 +97,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/pokedex/build.gradle.kts
+++ b/pokedex/build.gradle.kts
@@ -73,10 +73,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -85,7 +85,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -102,7 +102,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/showcase/build.gradle.kts
+++ b/showcase/build.gradle.kts
@@ -86,10 +86,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -98,7 +98,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -115,7 +115,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template-cordova/build.gradle.kts
+++ b/template-cordova/build.gradle.kts
@@ -70,10 +70,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -82,7 +82,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -99,7 +99,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template-electron/build.gradle.kts
+++ b/template-electron/build.gradle.kts
@@ -86,10 +86,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -98,7 +98,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -115,7 +115,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )
@@ -153,7 +153,7 @@ afterEvaluate {
             group = "run"
             workingDir = file("$buildDir/dist")
             executable = getNodeJsBinaryExecutable()
-            args("$buildDir/js/node_modules/electron/cli.js", ".")
+            args("${rootProject.buildDir}/js/node_modules/electron/cli.js", ".")
         }
         create("bundleApp", Exec::class) {
             dependsOn("buildApp")
@@ -167,7 +167,7 @@ afterEvaluate {
             }
             workingDir = file("$buildDir/dist")
             executable = getNodeJsBinaryExecutable()
-            args("$buildDir/js/node_modules/electron-builder/out/cli/cli.js", "--config")
+            args("${rootProject.buildDir}/js/node_modules/electron-builder/out/cli/cli.js", "--config")
         }
     }
 }

--- a/template-fullstack-javalin/build.gradle.kts
+++ b/template-fullstack-javalin/build.gradle.kts
@@ -129,10 +129,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -141,7 +141,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -158,7 +158,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template-fullstack-jooby/build.gradle.kts
+++ b/template-fullstack-jooby/build.gradle.kts
@@ -141,10 +141,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -159,7 +159,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -176,7 +176,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template-fullstack-ktor/build.gradle.kts
+++ b/template-fullstack-ktor/build.gradle.kts
@@ -145,10 +145,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -157,7 +157,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -174,7 +174,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template-fullstack-ktor/src/frontendMain/resources/i18n/messages.pot
+++ b/template-fullstack-ktor/src/frontendMain/resources/i18n/messages.pot
@@ -1,0 +1,4 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: \n"

--- a/template-fullstack-micronaut/build.gradle.kts
+++ b/template-fullstack-micronaut/build.gradle.kts
@@ -142,10 +142,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -154,7 +154,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -184,7 +184,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template-fullstack-spring-boot/build.gradle.kts
+++ b/template-fullstack-spring-boot/build.gradle.kts
@@ -140,10 +140,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -152,7 +152,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -169,7 +169,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template-fullstack-vertx/build.gradle.kts
+++ b/template-fullstack-vertx/build.gradle.kts
@@ -131,10 +131,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -148,7 +148,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -166,7 +166,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/template/build.gradle.kts
+++ b/template/build.gradle.kts
@@ -84,10 +84,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -96,7 +96,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -113,7 +113,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/todomvc/build.gradle.kts
+++ b/todomvc/build.gradle.kts
@@ -66,10 +66,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -78,7 +78,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinJs")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["main"].kotlin.files)
         outputs.file("$projectDir/src/main/resources/i18n/messages.pot")
     }
@@ -95,7 +95,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/tweets-fullstack-javalin/build.gradle.kts
+++ b/tweets-fullstack-javalin/build.gradle.kts
@@ -116,10 +116,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -128,7 +128,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -145,7 +145,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/tweets-fullstack-jooby/build.gradle.kts
+++ b/tweets-fullstack-jooby/build.gradle.kts
@@ -120,10 +120,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -138,7 +138,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -155,7 +155,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/tweets-fullstack-ktor/build.gradle.kts
+++ b/tweets-fullstack-ktor/build.gradle.kts
@@ -123,10 +123,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -135,7 +135,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -152,7 +152,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/tweets-fullstack-micronaut/build.gradle.kts
+++ b/tweets-fullstack-micronaut/build.gradle.kts
@@ -142,10 +142,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -154,7 +154,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -184,7 +184,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/tweets-fullstack-spring-boot-rpc/build.gradle.kts
+++ b/tweets-fullstack-spring-boot-rpc/build.gradle.kts
@@ -130,10 +130,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -142,7 +142,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -159,7 +159,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/tweets-fullstack-spring-boot/build.gradle.kts
+++ b/tweets-fullstack-spring-boot/build.gradle.kts
@@ -130,10 +130,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -142,7 +142,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -159,7 +159,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )

--- a/tweets-fullstack-vertx/build.gradle.kts
+++ b/tweets-fullstack-vertx/build.gradle.kts
@@ -118,10 +118,10 @@ kotlin {
 }
 
 fun getNodeJsBinaryExecutable(): String {
-    val nodeDir = NodeJsRootPlugin.apply(project).nodeJsSetupTaskProvider.get().destination
+    val nodeDir = NodeJsRootPlugin.apply(rootProject).nodeJsSetupTaskProvider.get().destination
     val isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
     val nodeBinDir = if (isWindows) nodeDir else nodeDir.resolve("bin")
-    val command = NodeJsRootPlugin.apply(project).nodeCommand
+    val command = NodeJsRootPlugin.apply(rootProject).nodeCommand
     val finalCommand = if (isWindows && command == "node") "node.exe" else command
     return nodeBinDir.resolve(finalCommand).absolutePath
 }
@@ -135,7 +135,7 @@ tasks {
     create("generatePotFile", Exec::class) {
         dependsOn("compileKotlinFrontend")
         executable = getNodeJsBinaryExecutable()
-        args("$buildDir/js/node_modules/gettext-extract/bin/gettext-extract")
+        args("${rootProject.buildDir}/js/node_modules/gettext-extract/bin/gettext-extract")
         inputs.files(kotlin.sourceSets["frontendMain"].kotlin.files)
         outputs.file("$projectDir/src/frontendMain/resources/i18n/messages.pot")
     }
@@ -153,7 +153,7 @@ afterEvaluate {
                     exec {
                         executable = getNodeJsBinaryExecutable()
                         args(
-                            "$buildDir/js/node_modules/gettext.js/bin/po2json",
+                            "${rootProject.buildDir}/js/node_modules/gettext.js/bin/po2json",
                             it.absolutePath,
                             "${it.parent}/${it.nameWithoutExtension}.json"
                         )


### PR DESCRIPTION
This allows usage of the build script in existing gradle project structures